### PR TITLE
Add support for transparency in source image

### DIFF
--- a/primitive/core.go
+++ b/primitive/core.go
@@ -72,45 +72,53 @@ func differenceFull(a, b *image.RGBA) float64 {
 			ar := int(a.Pix[i])
 			ag := int(a.Pix[i+1])
 			ab := int(a.Pix[i+2])
+			aa := int(a.Pix[i+3])
 			br := int(b.Pix[i])
 			bg := int(b.Pix[i+1])
 			bb := int(b.Pix[i+2])
+			ba := int(b.Pix[i+3])
 			i += 4
 			dr := ar - br
 			dg := ag - bg
 			db := ab - bb
-			total += uint64(dr*dr + dg*dg + db*db)
+			da := aa - ba
+			total += uint64(dr*dr + dg*dg + db*db + da*da)
 		}
 	}
-	return math.Sqrt(float64(total)/float64(w*h*3)) / 255
+	return math.Sqrt(float64(total)/float64(w*h*4)) / 255
 }
 
 func differencePartial(target, before, after *image.RGBA, score float64, lines []Scanline) float64 {
 	size := target.Bounds().Size()
 	w, h := size.X, size.Y
-	total := uint64(math.Pow(score*255, 2) * float64(w*h*3))
+	total := uint64(math.Pow(score*255, 2) * float64(w*h*4))
 	for _, line := range lines {
 		i := target.PixOffset(line.X1, line.Y)
 		for x := line.X1; x <= line.X2; x++ {
 			tr := int(target.Pix[i])
 			tg := int(target.Pix[i+1])
 			tb := int(target.Pix[i+2])
+			ta := int(target.Pix[i+3])
 			br := int(before.Pix[i])
 			bg := int(before.Pix[i+1])
 			bb := int(before.Pix[i+2])
+			ba := int(before.Pix[i+3])
 			ar := int(after.Pix[i])
 			ag := int(after.Pix[i+1])
 			ab := int(after.Pix[i+2])
+			aa := int(after.Pix[i+3])
 			i += 4
 			dr1 := tr - br
 			dg1 := tg - bg
 			db1 := tb - bb
+			da1 := ta - ba
 			dr2 := tr - ar
 			dg2 := tg - ag
 			db2 := tb - ab
-			total -= uint64(dr1*dr1 + dg1*dg1 + db1*db1)
-			total += uint64(dr2*dr2 + dg2*dg2 + db2*db2)
+			da2 := ta - aa
+			total -= uint64(dr1*dr1 + dg1*dg1 + db1*db1 + da1*da1)
+			total += uint64(dr2*dr2 + dg2*dg2 + db2*db2 + da2*da2)
 		}
 	}
-	return math.Sqrt(float64(total)/float64(w*h*3)) / 255
+	return math.Sqrt(float64(total)/float64(w*h*4)) / 255
 }


### PR DESCRIPTION
[Resolves fogleman/primitive#31] 

## Overview
As a result of the two difference functions not accounting for transparency, when the hill climb occurs, it will often place spurious primitives that are designed to match the background. While for many use cases this isn't really an issue, when dealing with transparent or semi-transparent pngs, it can be a bit problematic. Here is an example of the modified version in action, executed with `-bg 00000000`:

<img src='https://cloud.githubusercontent.com/assets/1497954/20823772/39902c44-b825-11e6-9db2-550976af1888.png' width='192' />
<img src='https://cloud.githubusercontent.com/assets/1497954/20823776/3ecabf44-b825-11e6-9bdc-11cfae8e2113.png' width='192' />
<img src='https://cloud.githubusercontent.com/assets/1497954/20823775/3ec6de10-b825-11e6-8714-bbefb566704c.png' width='192' />

The left-most image was the original source. Notice the transparent background and semi-transparent lens region. In the middle image, the current version of primitive, a number of unwanted black ellipses are placed. Once you tell the algorithm to pay attention to transparency, the results improve drastically as shown in the right-most image (n.b. some of the black ellipses are from the shadow, however it is easy to see that many of them have no corresponding visible counterpart).

## Concerns
While this should not affect the output on fully opaque images, it may result in a slight speed decrease, as there is now one additional array access per pixel in the difference algorithm. While I was not able to notice any change, this is worth considering.

