### PR TITLE
Adding -blur flag for SVG Blur filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Small input images should be used (like 256x256px). You don't need the detail an
 | `s` | 1024 | output image size |
 | `a` | 128 | color alpha (use `0` to let the algorithm choose alpha for each shape) |
 | `bg` | avg | starting background color (hex) |
+| `blur` | 0 | making SVG blured, adds blur filter witn N deviation. 0 - disabled. |
 | `j` | 0 | number of parallel workers (default uses all cores) |
 | `v` | off | verbose output |
 | `vv` | off | very verbose output |

--- a/main.go
+++ b/main.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fogleman/primitive/primitive"
 	"github.com/nfnt/resize"
+	"github.com/ramainen/primitive/primitive"
 )
 
 var (
 	Input      string
 	Outputs    flagArray
+	BlurFilter int
 	Background string
 	Configs    shapeConfigArray
 	Alpha      int
@@ -65,6 +66,7 @@ func init() {
 	flag.StringVar(&Input, "i", "", "input image path")
 	flag.Var(&Outputs, "o", "output image path")
 	flag.Var(&Configs, "n", "number of primitives")
+	flag.IntVar(&BlurFilter, "blur", 0, "make N bloor (for svg, 0 - disabled)")
 	flag.StringVar(&Background, "bg", "", "background color (hex)")
 	flag.IntVar(&Alpha, "a", 128, "alpha value")
 	flag.IntVar(&InputSize, "r", 256, "resize large input images to this size")
@@ -153,7 +155,7 @@ func main() {
 	}
 
 	// run algorithm
-	model := primitive.NewModel(input, bg, OutputSize, Workers)
+	model := primitive.NewModel(input, bg, OutputSize, Workers, BlurFilter)
 	primitive.Log(1, "%d: t=%.3f, score=%.6f\n", 0, 0.0, model.Score)
 	start := time.Now()
 	frame := 0

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fogleman/primitive/primitive"
+	"github.com/ramainen/primitive/primitive"
 	"github.com/nfnt/resize"
 )
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/nfnt/resize"
-	"github.com/ramainen/primitive/primitive"
+	"github.com/fogleman/primitive/primitive"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func init() {
 	flag.StringVar(&Input, "i", "", "input image path")
 	flag.Var(&Outputs, "o", "output image path")
 	flag.Var(&Configs, "n", "number of primitives")
-	flag.IntVar(&BlurFilter, "blur", 0, "make N bloor (for svg, 0 - disabled)")
+	flag.IntVar(&BlurFilter, "blur", 0, "make N blur (for svg, 0 - disabled)")
 	flag.StringVar(&Background, "bg", "", "background color (hex)")
 	flag.IntVar(&Alpha, "a", 128, "alpha value")
 	flag.IntVar(&InputSize, "r", 256, "resize large input images to this size")

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nfnt/resize"
 	"github.com/fogleman/primitive/primitive"
+	"github.com/nfnt/resize"
 )
 
 var (


### PR DESCRIPTION
New `-blur` flag. Default: 0, disables feature. Adds blur to resulting SVG output with deviation.
Example:

`primitive -i mona.png -o output.svg -r 256 -n 10 -m 0 -blur 10`

![image](https://user-images.githubusercontent.com/1003780/30956937-68d6025e-a441-11e7-956b-c46179cbdf33.png)


