### PR TITLE
Reduce generated SVG file size

### DIFF
--- a/primitive/model.go
+++ b/primitive/model.go
@@ -88,11 +88,11 @@ func (model *Model) SVG() string {
 	var lines []string
 	lines = append(lines, fmt.Sprintf("<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" width=\"%d\" height=\"%d\">", model.Sw, model.Sh))
 	lines = append(lines, fmt.Sprintf("<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"#%02x%02x%02x\" />", model.Sw, model.Sh, bg.R, bg.G, bg.B))
-	lines = append(lines, fmt.Sprintf("<g transform=\"scale(%f) translate(0.5 0.5)\">", model.Scale))
+	lines = append(lines, fmt.Sprintf("<g transform=\"scale(%f) translate(0.5 0.5)\" fill-opacity=\"%f\">", model.Scale, float64(model.Colors[0].A)/255))
 	for i, shape := range model.Shapes {
 		c := model.Colors[i]
-		attrs := "fill=\"#%02x%02x%02x\" fill-opacity=\"%f\""
-		attrs = fmt.Sprintf(attrs, c.R, c.G, c.B, float64(c.A)/255)
+		attrs := "fill=\"#%02x%02x%02x\""
+		attrs = fmt.Sprintf(attrs, c.R, c.G, c.B)
 		lines = append(lines, shape.SVG(attrs))
 	}
 	lines = append(lines, "</g>")


### PR DESCRIPTION
Since this project takes alpha from a global config, all shapes share the same opacity.

Giving alpha to the parent element, reduces size of generated SVG by 31% for n=100

