### PR TITLE
Prevent recalculating the same thing over and over again

### DIFF
--- a/primitive/core.go
+++ b/primitive/core.go
@@ -46,17 +46,22 @@ func drawLines(im *image.RGBA, c Color, lines []Scanline) {
 	sr, sg, sb, sa := c.NRGBA().RGBA()
 	for _, line := range lines {
 		ma := line.Alpha
-		a := (m - sa*ma/m) * 0x101
+		sra := sr * ma
+		sga := sg * ma
+		sba := sb * ma
+		saa := sa * ma
+
+		a := (m - saa/m) * 0x101
 		i := im.PixOffset(line.X1, line.Y)
 		for x := line.X1; x <= line.X2; x++ {
 			dr := uint32(im.Pix[i+0])
 			dg := uint32(im.Pix[i+1])
 			db := uint32(im.Pix[i+2])
 			da := uint32(im.Pix[i+3])
-			im.Pix[i+0] = uint8((dr*a + sr*ma) / m >> 8)
-			im.Pix[i+1] = uint8((dg*a + sg*ma) / m >> 8)
-			im.Pix[i+2] = uint8((db*a + sb*ma) / m >> 8)
-			im.Pix[i+3] = uint8((da*a + sa*ma) / m >> 8)
+			im.Pix[i+0] = uint8((dr*a + sra) / m >> 8)
+			im.Pix[i+1] = uint8((dg*a + sga) / m >> 8)
+			im.Pix[i+2] = uint8((db*a + sba) / m >> 8)
+			im.Pix[i+3] = uint8((da*a + saa) / m >> 8)
 			i += 4
 		}
 	}


### PR DESCRIPTION
Those values were calculated too many times and this leads to a possible small improvement in speed.