### PR TITLE
Add docker usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Run it on your own images! First, [install Go](https://golang.org/doc/install).
     go get -u github.com/fogleman/primitive
     primitive -i input.png -o output.png -n 100
 
+Alternatively, you can use [Docker](https://docs.docker.com/install/).
+    
+    docker run -v ${PWD}:/tmp golang sh -c 'go get -u github.com/fogleman/primitive; primitive -i /tmp/input.png -o /tmp/output.png -n 100'
+
+
 Small input images should be used (like 256x256px). You don't need the detail anyway and the code will run faster.
 
 | Flag | Default | Description |


### PR DESCRIPTION
Just a quick PR to add a simple docker usage in the README.  
It allows to run primitive without installing Go and primitive itself.

I was thinking to create a Dockerfile and maybe push the image on the [DockerHub](https://hub.docker.com/), but I though a simple one-liner would be enough since installing primitive in the base golang image is really quick.
Let me know what you think about it.