### PR TITLE
fix: mutate width on quadratic shapes

### DIFF
--- a/primitive/quadratic.go
+++ b/primitive/quadratic.go
@@ -56,7 +56,7 @@ func (q *Quadratic) Mutate() {
 	h := q.Worker.H
 	rnd := q.Worker.Rnd
 	for {
-		switch rnd.Intn(3) {
+		switch rnd.Intn(4) {
 		case 0:
 			q.X1 = clamp(q.X1+rnd.NormFloat64()*16, -m, float64(w-1+m))
 			q.Y1 = clamp(q.Y1+rnd.NormFloat64()*16, -m, float64(h-1+m))


### PR DESCRIPTION
The width mutation option was never chosen due to an off-by-one error, leaving the resulting lines very thin.
## Before fix
![old_mona_100](https://github.com/user-attachments/assets/e6ff00b1-88e9-47ca-9e43-9485d88237a1)
## After fix
![new_mona_100](https://github.com/user-attachments/assets/b33773d0-d816-4902-8c47-d814b0199836)
